### PR TITLE
Performance improvements

### DIFF
--- a/src/commands/command_handler.cpp
+++ b/src/commands/command_handler.cpp
@@ -10,7 +10,7 @@ CommandHandler::CommandHandler()
 CommandHandler::~CommandHandler()
 {
     std::list<ICmd*>::iterator it;
-    for (it = m_cmd_stack.begin(); it != m_cmd_stack.end(); it++) delete (*it);
+    for (it = m_cmd_stack.begin(); it != m_cmd_stack.end(); ++it) delete (*it);
 } // ~CommandHandler
 
 // ----------------------------------------------------------------------------
@@ -18,7 +18,7 @@ void CommandHandler::add(ICmd* cmd)
 {
     std::list<ICmd*>::iterator it;
 
-    for (it = m_it; it != m_cmd_stack.end(); it++) delete (*it);
+    for (it = m_it; it != m_cmd_stack.end(); ++it) delete (*it);
     m_it = m_cmd_stack.erase(m_it, it);
 
     m_it = m_cmd_stack.insert(m_it, cmd);
@@ -50,7 +50,7 @@ void CommandHandler::undo()
 void CommandHandler::clear()
 {
     std::list<ICmd*>::iterator it;
-    for (it = m_cmd_stack.begin(); it != m_cmd_stack.end(); it++) delete (*it);
+    for (it = m_cmd_stack.begin(); it != m_cmd_stack.end(); ++it) delete (*it);
     m_cmd_stack.clear();
 } // undo
 

--- a/src/commands/height_mod_cmd.cpp
+++ b/src/commands/height_mod_cmd.cpp
@@ -62,7 +62,7 @@ void HeightModCmd::finish()
 void HeightModCmd::undo()
 {
     std::list<std::pair<float*, float> >::iterator it;
-    for (it = m_list.begin(); it != m_list.end(); it++)
+    for (it = m_list.begin(); it != m_list.end(); ++it)
         *(it->first) -= it->second;
     m_terrain->recalculateNormals();
 } // undo
@@ -71,7 +71,7 @@ void HeightModCmd::undo()
 void HeightModCmd::redo()
 {
     std::list<std::pair<float*, float> >::iterator it;
-    for (it = m_list.begin(); it != m_list.end(); it++)
+    for (it = m_list.begin(); it != m_list.end(); ++it)
         *(it->first) += it->second;
     m_terrain->recalculateNormals();
 } // redo

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1027,7 +1027,7 @@ void Editor::addToRecentlyOpenedList(stringc name)
     list = readRecentlyOpenedList();
 
     std::list<stringc>::iterator it;
-    for (it = list.begin(); it != list.end(); it++)
+    for (it = list.begin(); it != list.end(); ++it)
         if ((*it) == name) return;
 
     if (list.size() >= EVIL_NUMBER)
@@ -1041,7 +1041,7 @@ void Editor::addToRecentlyOpenedList(stringc name)
     f << "<files>\n";
 
     it = list.begin();
-    for (; it != list.end(); it++)
+    for (; it != list.end(); ++it)
     {
         f << "  <file name=\"" << (*it).c_str() << "\" />\n";
     }

--- a/src/gui/env_panel.cpp
+++ b/src/gui/env_panel.cpp
@@ -29,7 +29,7 @@ void EnvPanel::init()
     m_lib = new Library(L"env", m_btn_num);
     std::list<stringw> list = m_lib->getCategoryList();
     std::list<stringw>::iterator it;
-    for (it = list.begin(); it != list.end(); it++)
+    for (it = list.begin(); it != list.end(); ++it)
     {
         m_cb->addItem((*it).c_str());
     }
@@ -111,7 +111,7 @@ void EnvPanel::refreshBtnTable()
 
     stringw dir = L"editor/img/";
     int i;
-    for (i = 0; i < m_btn_num && it != elements.end(); i++, it++)
+    for (i = 0; i < m_btn_num && it != elements.end(); i++, ++it)
     {
         ITexture* img = Editor::loadImg(dir+(*it)->getImg());
         if (!img) img = Editor::loadImg(dir + "noimg.png");

--- a/src/gui/library.cpp
+++ b/src/gui/library.cpp
@@ -87,12 +87,12 @@ std::list<Element*> Library::getElements(unsigned int ix)
     std::list<Element*> elements;
     std::list<Element*>::iterator it = m_selected_elements.begin();
 
-    for (unsigned int i = 0; i < ix * m_buffer_size; i++, it++);
+    for (unsigned int i = 0; i < ix * m_buffer_size; i++, ++it);
 
     for (unsigned int i = 0; i < m_buffer_size && it != m_selected_elements.end(); i++)
     {
         elements.push_back(*it);
-        it++;
+        ++it;
     }
 
     return elements;
@@ -116,7 +116,7 @@ Library::~Library()
     {
         std::list<Element*> list = *(*it).second;
         std::list<Element*>::iterator iit;
-        for (iit = list.begin(); iit != list.end(); iit++)
+        for (iit = list.begin(); iit != list.end(); ++iit)
             delete (*iit);
         delete (*it).second;
     }

--- a/src/gui/welcome_screen.cpp
+++ b/src/gui/welcome_screen.cpp
@@ -35,7 +35,7 @@ void WelcomeScreen::init()
     std::list<stringc> list;
     std::list<stringc>::iterator it;
     list = Editor::getEditor()->readRecentlyOpenedList();
-    for (it = list.begin(); it != list.end(); it++)
+    for (it = list.begin(); it != list.end(); ++it)
     {
         stringw s = *it;
         m_lb->addItem(s.c_str());

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -244,7 +244,6 @@ Track::Track(path file)
 
     // ROADS
 
-    IRoad* r;
     fread(&size, sizeof(u8), 1, pFile);
     if (size < 0 || size > MAX_ROAD_NUM)
     {
@@ -252,6 +251,7 @@ Track::Track(path file)
     }
     else
     {
+        IRoad* r;
         if (size > 0)
         {
             m_driveline = new DriveLine(sm->getRootSceneNode(), sm, 0, pFile);

--- a/src/viewport/checkline_handler.cpp
+++ b/src/viewport/checkline_handler.cpp
@@ -6,7 +6,7 @@
 ISceneNode* CheckLineHandler::startPlacingNew()
 {
     std::list<CheckLine>::iterator it = m_check_lines.begin();
-    while (it != m_check_lines.end() && it->active) it++;
+    while (it != m_check_lines.end() && it->active) ++it;
     m_check_lines.erase(it, m_check_lines.end());
 
     ISceneManager* sm = Editor::getEditor()->getSceneManager();
@@ -40,8 +40,8 @@ void CheckLineHandler::undo()
     if (m_check_lines.size() == 0) return;
 
     std::list<CheckLine>::iterator it = m_check_lines.begin();
-    while (it != m_check_lines.end() && it->active) it++;
-    if (it != m_check_lines.begin()) it--;
+    while (it != m_check_lines.end() && it->active) ++it;
+    if (it != m_check_lines.begin()) --it;
 
     it->active = false;
     it->n1->setVisible(false);
@@ -52,7 +52,7 @@ void CheckLineHandler::undo()
 void CheckLineHandler::redo()
 {
     std::list<CheckLine>::iterator it = m_check_lines.begin();
-    while (it != m_check_lines.end() && it->active) it++;
+    while (it != m_check_lines.end() && it->active) ++it;
     if (it != m_check_lines.end())
     {
         it->active = true;
@@ -68,7 +68,7 @@ bool CheckLineHandler::isCheckLine(ISceneNode* n)
     while (it != m_check_lines.end())
     {
         if (&(*it->n1) == n || &(*it->n2) == n) return true;
-        it++;
+        ++it;
     }
     return false;
 } // isCheckLine
@@ -86,7 +86,7 @@ void CheckLineHandler::remove(ISceneNode* n, bool remove)
             it->n2->setVisible(!remove);
             return;
         }
-        it++;
+        ++it;
     }
 } // remove
 
@@ -116,7 +116,7 @@ void CheckLineHandler::build(std::ofstream* scene)
     while (it != m_check_lines.end() && it->active)
     {
         if (!it->removed) i++;
-        it++;
+        ++it;
     }
 
     if (i>0)
@@ -128,7 +128,7 @@ void CheckLineHandler::build(std::ofstream* scene)
         {
             if (it->removed)
             {
-                it++;
+                ++it;
             }
             else
             {
@@ -137,13 +137,13 @@ void CheckLineHandler::build(std::ofstream* scene)
                 (*scene) << "    <check-line kind=\"activate\" other-ids=\"" << j + 2;
                 (*scene) << "\" p1=\"" << p1.X << " " << p1.Y << " " << p1.Z << "\" p2=\"" << p2.X;
                 (*scene) << " " << p2.Y << " " << p2.Z << "\" same-group=\"" << j + 1 << "\"/>\n";
-                it++;
+                ++it;
                 j++;
             }
         }
 
         std::list<CheckLine>::iterator it2 = m_check_lines.begin();
-        for (it2 = m_check_lines.begin(); it2 != m_check_lines.end(); it2++)
+        for (it2 = m_check_lines.begin(); it2 != m_check_lines.end(); ++it2)
             if (!it->removed && it->active) it = it2;
 
         p1 = it->n1->getPosition();
@@ -166,7 +166,7 @@ void CheckLineHandler::save(FILE* fp)
     while (it != m_check_lines.end() && it->active)
     {
         if (!it->removed) size++;
-        it++;
+        ++it;
     }
     fwrite(&size, sizeof(u32), 1, fp);
     
@@ -178,7 +178,7 @@ void CheckLineHandler::save(FILE* fp)
             fwrite(&it->n1->getPosition(), sizeof(vector3df), 1, fp);
             fwrite(&it->n2->getPosition(), sizeof(vector3df), 1, fp);
         }
-        it++;
+        ++it;
     }
 } // save
 
@@ -192,7 +192,7 @@ void CheckLineHandler::reload(FILE* fp)
         it->n1 = 0;
         it->n2->remove();
         it->n2 = 0;
-        it++;
+        ++it;
     }
     m_check_lines.clear();
     
@@ -233,6 +233,6 @@ void CheckLineHandler::draw()
             vd->draw3DLine(it->n1->getPosition(), it->n2->getPosition(),
                                                 SColor(255, 255, 0, 0));
         }
-        it++;
+        ++it;
     }
 } // draw


### PR DESCRIPTION
Use prefix instead of postfix operators for iterations and reduce the scope of a variable as indicated by cppcheck to increase performance.
