### PR TITLE
Fix a couple of memory and resource leaks.

### DIFF
--- a/src/autodropped.hpp
+++ b/src/autodropped.hpp
@@ -1,0 +1,16 @@
+#include <memory>
+#include <utility>
+
+template<class T>
+void dropReferenceCounted(T* ref_counted)
+{
+    if (ref_counted)
+        ref_counted->drop();
+}
+
+template<class T>
+std::unique_ptr<T, decltype(&dropReferenceCounted<T>)> autoDropped(T* ref_counted)
+{
+    return std::unique_ptr<T, decltype(&dropReferenceCounted<T>)>(
+        ref_counted, dropReferenceCounted);
+}

--- a/src/mesh/terrain.cpp
+++ b/src/mesh/terrain.cpp
@@ -6,9 +6,12 @@
 
 #include "commands/iterrain_cmd.hpp"
 
+#include "autodropped.hpp"
+
 #include <algorithm>
 #include <assert.h>
 #include <iostream>
+#include <memory>
 
 const u32 Terrain::SPIMG_X = 1024;
 const u32 Terrain::SPIMG_Y = 1024;
@@ -242,14 +245,14 @@ ITexture* Terrain::createSplattingImg()
 {
     IVideoDriver* vd = Editor::getEditor()->getVideoDriver();
 
-    IImage* img = vd->createImage(ECF_A8R8G8B8, dimension2du(SPIMG_X, SPIMG_Y));
+    auto img = autoDropped(
+        vd->createImage(ECF_A8R8G8B8, dimension2du(SPIMG_X, SPIMG_Y)));
 
     for (u32 i = 0; i < SPIMG_X; i++)
         for (u32 j = 0; j < SPIMG_Y; j++)
             img->setPixel(i, j, SColor(255, 0, 0, 0));
 
-    m_splattingImg = img;
-    return vd->addTexture("splatt.png", img);
+    return vd->addTexture("splatt.png", img.get());
 } // initSplattingImg
 
 // ----------------------------------------------------------------------------

--- a/src/mesh/terrain.hpp
+++ b/src/mesh/terrain.hpp
@@ -39,8 +39,6 @@ private:
     SMaterial           m_material;
     SMaterial           m_highlight_material;
 
-    IImage*             m_splattingImg;
-
     u16                 m_tile_num_x;
     u16                 m_tile_num_z;
 

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <stdio.h>
 #include <assert.h>
+#include <memory>
 
 #define TOP_SECRET_SIGNATURE_NUMBER 3293525171
 #define MAX_ROAD_NUM 1000
@@ -244,7 +245,6 @@ Track::Track(path file)
 
     // ROADS
 
-    IRoad* r;
     fread(&size, sizeof(u8), 1, pFile);
     if (size < 0 || size > MAX_ROAD_NUM)
     {
@@ -266,13 +266,15 @@ Track::Track(path file)
         } // driveline
         for (u8 i = 1; i < size; i++)
         {
-            r = new Road(sm->getRootSceneNode(), sm, 0, pFile);
+            std::unique_ptr<IRoad> r(new Road(sm->getRootSceneNode(), sm, 0, pFile));
             if (r->isValid())
             {
-                m_roads.push_back(r);
+                m_roads.push_back(r.get());
                 r->refresh();
                 r->setWireFrame(false);
                 Viewport::get()->setSplineMode(false);
+		// Explicitly release r to prevent it from being deleted.
+                r.release();
             }
             else std::cerr << "Warning: invalid road - skipped :(\n";
         } // roads


### PR DESCRIPTION
- Some local variables were allocated with new but never deleted.
  They now use std::auto_ptr to prevent that from happening again.
  std::unique_ptr would allow us to get rid of even more explicit
  deletes, but the style guide for supertuxkart forbids using C++11
  features.
- Some irr::IReferenceCounted objects were not released with drop().
  A new template class, AutoDrop, which works the same way as
  std::auto_ptr, takes care of them.
