### PR TITLE
Stop camera distortion when resizing window

### DIFF
--- a/src/viewport/aztec_camera.cpp
+++ b/src/viewport/aztec_camera.cpp
@@ -130,6 +130,7 @@ void AztecCamera::processKeys(f32 dt)
 // ----------------------------------------------------------------------------
 void AztecCamera::processMouse(f32 dt)
 {
+    setHeight();
     if (m_mouse->middlePressed())
         m_mmb_move = m_keys->m_key_state[SHIFT_PRESSED];
     if (m_mouse->middleReleased())


### PR DESCRIPTION
### Before: View would stretch strangely if you resize the window. 
![image](https://user-images.githubusercontent.com/73035340/173871298-342d5166-de7c-47d1-b98f-90660e2f4603.png)
![image](https://user-images.githubusercontent.com/73035340/173871321-ba7dce91-1703-4a1e-885c-dd1640d89cdd.png)

### After:  It should no longer do this
![image](https://user-images.githubusercontent.com/73035340/173873968-ccc9b693-b501-4e16-a252-d8aa95cbabef.png)
![image](https://user-images.githubusercontent.com/73035340/173874174-d269787f-73ab-4df8-a2f6-0e82ea788f97.png)
